### PR TITLE
Closes #26 Fix agil.yaml adding keys to the testing hash.

### DIFF
--- a/agil.yaml
+++ b/agil.yaml
@@ -17,5 +17,5 @@ test:
 aserciones: "@pytest"
 
 testing:
-  - runner: mask
-  - framework: pytest
+  runner: mask
+  framework: pytest


### PR DESCRIPTION
Small fix to agil.yaml #26 